### PR TITLE
Cancel in-progress task to query the current server when switching servers

### DIFF
--- a/DayZServerMonitorCore/IClient.cs
+++ b/DayZServerMonitorCore/IClient.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DayZServerMonitorCore
 {
     public interface IClient : IDisposable
     {
-        Task<byte[]> Request(byte[] request, int timeout);
+        Task<byte[]> Request(byte[] request, int timeout, CancellationTokenSource source);
     }
 
     public interface IClientFactory

--- a/DayZServerMonitorCore/MasterServerQuerier.cs
+++ b/DayZServerMonitorCore/MasterServerQuerier.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DayZServerMonitorCore
@@ -22,7 +23,7 @@ namespace DayZServerMonitorCore
         }
 
         public async Task<Server> FindDayZServerInRegion(
-            string host, int port, byte region, int timeout)
+            string host, int port, byte region, int timeout, CancellationTokenSource source)
         {
             try
             {
@@ -36,7 +37,7 @@ namespace DayZServerMonitorCore
                     request.AddRange(Encoding.UTF8.GetBytes(string.Format("{0}:{1}", host, port)));
                     request.Add(0);
 
-                    byte[] response = await client.Request(request.ToArray(), timeout);
+                    byte[] response = await client.Request(request.ToArray(), timeout, source);
                     MessageParser parser = new MessageParser(response);
                     _ = parser.GetBytes(6);
                     IPAddress ip = parser.GetIPAddress();

--- a/DayZServerMonitorCore/ServerInfoQuerier.cs
+++ b/DayZServerMonitorCore/ServerInfoQuerier.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DayZServerMonitorCore
@@ -16,7 +17,7 @@ namespace DayZServerMonitorCore
             this.logger = logger;
         }
 
-        public async Task<ServerInfo> Query(string host, int port, int timeout)
+        public async Task<ServerInfo> Query(string host, int port, int timeout, CancellationTokenSource source)
         {
             logger.Status($"Reading DayZ server status at {host}:{port}");
             try
@@ -27,7 +28,7 @@ namespace DayZServerMonitorCore
                     request.AddRange(Encoding.UTF8.GetBytes("Source Engine Query"));
                     request.Add(0);
 
-                    byte[] response = await client.Request(request.ToArray(), timeout);
+                    byte[] response = await client.Request(request.ToArray(), timeout, source);
 
                     ServerInfo info = ServerInfo.Parse(host, port, response);
 

--- a/TestDayZServerMonitorCore/MockClient.cs
+++ b/TestDayZServerMonitorCore/MockClient.cs
@@ -13,12 +13,14 @@ namespace TestDayZServerMonitorCore
         internal byte[] ServerRequest { get; private set; }
         internal int ServerTimeout { get; private set; }
         internal Action RequestAction { get; set; }
+        internal CancellationTokenSource Source { get; set; }
 
-        public Task<byte[]> Request(byte[] request, int timeout)
+        public Task<byte[]> Request(byte[] request, int timeout, CancellationTokenSource source)
         {
             RequestAction?.Invoke();
             ServerRequest = request;
             ServerTimeout = timeout;
+            Source = source;
             if (ServerError != null)
             {
                 throw ServerError;


### PR DESCRIPTION
This should fix certain conditions that cause the app to stop responding to server changes.