### PR TITLE
Remove semaphore from Monitor class

### DIFF
--- a/DayZServerMonitorForm.Designer.cs
+++ b/DayZServerMonitorForm.Designer.cs
@@ -23,10 +23,6 @@
                 {
                     watcher.Dispose();
                 }
-                if (monitor != null)
-                {
-                    monitor.Dispose();
-                }
                 if (dynamicIcons != null)
                 {
                     dynamicIcons.Dispose();

--- a/TestDayZServerMonitorCore/TestMonitor.cs
+++ b/TestDayZServerMonitorCore/TestMonitor.cs
@@ -39,7 +39,6 @@ namespace TestDayZServerMonitorCore
             clock.Dispose();
             masterServerClient.Dispose();
             serverInfoClient.Dispose();
-            monitor.Dispose();
             source.Dispose();
         }
 


### PR DESCRIPTION
The semaphore in the `Monitor` class appears to be the cause of the tool soft hanging. Somehow, the semaphore does not get released when it should (despite it being in a `finally` block), leaving it with a stale acquire. From that point forward, server polling stops happening at all.

The semaphore was originally added to prevent multiple concurrent server queries. There is a risk that might now happen, however the "60 seconds since last query" check should prevent it, in most cases, so the risk should be low. Also, the impact should be small if it ever happens.

I believe this fixes #24 and may also fix #22.