### PR TITLE
Add "Check for Update" feature

### DIFF
--- a/DayZServerMonitorCore/DayZServerMonitorCore.csproj
+++ b/DayZServerMonitorCore/DayZServerMonitorCore.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 

--- a/DayZServerMonitorCore/Settings.cs
+++ b/DayZServerMonitorCore/Settings.cs
@@ -41,6 +41,7 @@ namespace DayZServerMonitorCore
         public enum NotifyOnPlayerCountValues { NEVER, WHEN_ABOVE, WHEN_BELOW };
         public const int NUM_STATUS_FILES = 4;
 
+        private bool checkForUpdates = true;
         private HideTaskBarIconValues hideTaskBarIcon = HideTaskBarIconValues.NEVER;
         private int maxLogViewerEntries = 100;
         private string logPathname = null;
@@ -58,10 +59,21 @@ namespace DayZServerMonitorCore
         private Color trayIconAlertBackground = Color.DarkRed;
         private Color trayIconAlertForeground = Color.Yellow;
 
+        public bool CheckForUpdates
+        {
+            get => checkForUpdates;
+            set
+            {
+                checkForUpdates = value;
+                OnSettingChanged();
+            }
+        }
+
         public HideTaskBarIconValues HideTaskBarIcon
         {
             get => hideTaskBarIcon;
-            set {
+            set
+            {
                 hideTaskBarIcon = value;
                 OnSettingChanged();
             }
@@ -203,6 +215,7 @@ namespace DayZServerMonitorCore
 
         public void Apply(Settings newSettings)
         {
+            CheckForUpdates = newSettings.CheckForUpdates;
             HideTaskBarIcon = newSettings.HideTaskBarIcon;
             MaxLogViewerEntries = newSettings.MaxLogViewerEntries;
             LogPathname = newSettings.LogPathname;

--- a/DayZServerMonitorCore/VersionChecker.cs
+++ b/DayZServerMonitorCore/VersionChecker.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace DayZServerMonitorCore
+{
+    public class VersionChecker
+    {
+        private static readonly string CHECK_URL = "https://tjensen.github.io/DayZServerMonitor/version.txt";
+
+        private readonly HttpClient client;
+        private readonly ILogger logger;
+
+        public VersionChecker(HttpClient client, ILogger logger)
+        {
+            this.client = client;
+            this.logger = logger;
+        }
+
+        public async Task<Version> Check()
+        {
+            try
+            {
+                var response = await client.GetAsync(CHECK_URL);
+                if (response.IsSuccessStatusCode)
+                {
+                    string content = await response.Content.ReadAsStringAsync();
+                    if (Version.TryParse(content, out Version version))
+                    {
+                        logger.Debug($"Got version {version} from {CHECK_URL}");
+
+                        return version;
+                    }
+                    else
+                    {
+                        logger.Debug(
+                            $"Unable to parse version returned by {CHECK_URL}: {version}");
+                    }
+                }
+                else
+                {
+                    logger.Debug($"GET {CHECK_URL} returned status {response.StatusCode}");
+                }
+            }
+            catch (Exception error)
+            {
+                logger.Debug($"Error making GET {CHECK_URL}: {error}");
+            }
+
+            return null;
+        }
+    }
+}

--- a/DayZServerMonitorForm.cs
+++ b/DayZServerMonitorForm.cs
@@ -580,7 +580,7 @@ namespace DayZServerMonitor
             }
             catch (Exception error)
             {
-                MessageBox.Show($"Failed to open URL: {error}", "Check for Updates");
+                MessageBox.Show($"Failed to open URL: {error}", "Check for Update");
             }
         }
 
@@ -670,6 +670,14 @@ namespace DayZServerMonitor
 
         private void OnUpdateChecked(bool automatic, Version latest)
         {
+            if (!automatic && latest is null)
+            {
+                MessageBox.Show(
+                    "There was a problem checking for an update. Please try again later.",
+                    "Check for Update");
+                return;
+            }
+
             var current = Assembly.GetExecutingAssembly().GetName().Version;
 
             if (current.CompareTo(latest) < 0)
@@ -692,7 +700,7 @@ namespace DayZServerMonitor
             {
                 MessageBox.Show(
                     "You are already running the latest version of DayZ Server Monitor!",
-                    "Check for Updates");
+                    "Check for Update");
             }
         }
 

--- a/DayZServerMonitorForm.cs
+++ b/DayZServerMonitorForm.cs
@@ -580,7 +580,9 @@ namespace DayZServerMonitor
             }
             catch (Exception error)
             {
-                MessageBox.Show($"Failed to open URL: {error}", "Check for Update");
+                MessageBox.Show(
+                    $"Failed to open URL: {error}", "Check for Update",
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -674,7 +676,7 @@ namespace DayZServerMonitor
             {
                 MessageBox.Show(
                     "There was a problem checking for an update. Please try again later.",
-                    "Check for Update");
+                    "Check for Update", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
@@ -700,7 +702,7 @@ namespace DayZServerMonitor
             {
                 MessageBox.Show(
                     "You are already running the latest version of DayZ Server Monitor!",
-                    "Check for Update");
+                    "Check for Update", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
         }
 

--- a/SettingsDialog.cs
+++ b/SettingsDialog.cs
@@ -8,6 +8,7 @@ namespace DayZServerMonitor
     public class SettingsDialog : Form
     {
         private readonly TableLayoutPanel mainPanel = new TableLayoutPanel();
+        private readonly CheckBox checkForUpdates = new CheckBox();
         private readonly ComboBox hideTaskBarIcon = new ComboBox();
         private readonly CheckBox alwaysOnTop = new CheckBox();
         private readonly NumericUpDown maxLogViewerEntries = new NumericUpDown();
@@ -54,6 +55,7 @@ namespace DayZServerMonitor
 
         public void ShowDialog(Settings settings)
         {
+            checkForUpdates.Checked = settings.CheckForUpdates;
             hideTaskBarIcon.SelectedItem = settings.HideTaskBarIcon;
             alwaysOnTop.Checked = settings.AlwaysOnTop;
             maxLogViewerEntries.Value = settings.MaxLogViewerEntries;
@@ -90,6 +92,7 @@ namespace DayZServerMonitor
 
             if (ShowDialog() == DialogResult.OK)
             {
+                settings.CheckForUpdates = checkForUpdates.Checked;
                 settings.HideTaskBarIcon =
                     (Settings.HideTaskBarIconValues)hideTaskBarIcon.SelectedItem;
                 settings.AlwaysOnTop = alwaysOnTop.Checked;
@@ -194,6 +197,9 @@ namespace DayZServerMonitor
             settingsPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 150));
             settingsPanel.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
             mainPanel.Controls.Add(settingsPanel);
+
+            checkForUpdates.Dock = DockStyle.Left;
+            InitializeSetting(settingsPanel, checkForUpdates, "Check for updates on startup");
 
             hideTaskBarIcon.Dock = DockStyle.Fill;
             hideTaskBarIcon.DropDownStyle = ComboBoxStyle.DropDownList;

--- a/TestDayZServerMonitorCore/TestDayZServerMonitorCore.csproj
+++ b/TestDayZServerMonitorCore/TestDayZServerMonitorCore.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeCoverage" Version="16.9.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
@@ -19,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 

--- a/TestDayZServerMonitorCore/TestSettings.cs
+++ b/TestDayZServerMonitorCore/TestSettings.cs
@@ -23,6 +23,7 @@ namespace TestDayZServerMonitorCore
         [TestMethod]
         public void IsConstructedWithDefaultSettings()
         {
+            Assert.IsTrue(settings.CheckForUpdates);
             Assert.AreEqual(Settings.HideTaskBarIconValues.NEVER, settings.HideTaskBarIcon);
             Assert.AreEqual(100, settings.MaxLogViewerEntries);
             Assert.IsNull(settings.LogPathname);
@@ -54,6 +55,7 @@ namespace TestDayZServerMonitorCore
         {
             Settings newSettings = new Settings()
             {
+                CheckForUpdates = false,
                 HideTaskBarIcon = Settings.HideTaskBarIconValues.ALWAYS,
                 MaxLogViewerEntries = 42,
                 LogPathname = "/path/to/log",
@@ -74,6 +76,7 @@ namespace TestDayZServerMonitorCore
 
             settings.Apply(newSettings);
 
+            Assert.IsFalse(settings.CheckForUpdates);
             Assert.AreEqual(Settings.HideTaskBarIconValues.ALWAYS, settings.HideTaskBarIcon);
             Assert.AreEqual(42, settings.MaxLogViewerEntries);
             Assert.AreEqual("/path/to/log", settings.LogPathname);
@@ -97,6 +100,7 @@ namespace TestDayZServerMonitorCore
         {
             Settings settingsToSave = new Settings()
             {
+                CheckForUpdates = false,
                 HideTaskBarIcon = Settings.HideTaskBarIconValues.ALWAYS,
                 MaxLogViewerEntries = 42,
                 LogPathname = "/path/to/log",
@@ -130,6 +134,7 @@ namespace TestDayZServerMonitorCore
                 settingsToLoad.Apply((Settings)serializer.Deserialize(reader));
             }
 
+            Assert.IsFalse(settingsToSave.CheckForUpdates);
             Assert.AreEqual(settingsToSave.HideTaskBarIcon, settingsToLoad.HideTaskBarIcon);
             Assert.AreEqual(settingsToSave.MaxLogViewerEntries,
                 settingsToLoad.MaxLogViewerEntries);
@@ -158,6 +163,14 @@ namespace TestDayZServerMonitorCore
                 settingsToLoad.TrayIconAlertBackground.ToArgb());
             Assert.AreEqual(settingsToSave.TrayIconAlertForeground.ToArgb(),
                 settingsToLoad.TrayIconAlertForeground.ToArgb());
+        }
+
+        [TestMethod]
+        public void SettingChangedIsInvokedWhenCheckForUpdatesChanges()
+        {
+            settings.CheckForUpdates = false;
+
+            Assert.AreEqual("CheckForUpdates", settingThatChanged);
         }
 
         [TestMethod]

--- a/TestDayZServerMonitorCore/TestVersionChecker.cs
+++ b/TestDayZServerMonitorCore/TestVersionChecker.cs
@@ -1,0 +1,109 @@
+﻿using DayZServerMonitorCore;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Moq.Protected;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TestDayZServerMonitorCore
+{
+    [TestClass]
+    public class TestVersionChecker
+    {
+        private readonly MockLogger logger = new MockLogger();
+
+        private static Mock<HttpMessageHandler> PrepareMockHandler(Object response)
+        {
+            var handlerMock = new Mock<HttpMessageHandler>();
+            var setup = handlerMock
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>());
+
+            if (response is Exception)
+            {
+                _ = setup.ThrowsAsync(response as Exception);
+            }
+            else
+            {
+                _ = setup.ReturnsAsync(response as HttpResponseMessage);
+            }
+
+            return handlerMock;
+        }
+
+        [TestMethod]
+        public async Task RequestsLatestVersionAndReturnsIt()
+        {
+            var handlerMock = PrepareMockHandler(
+                new HttpResponseMessage {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("1.2.3.4\n")
+                });
+            var client = new HttpClient(handlerMock.Object);
+            var checker = new VersionChecker(client, logger);
+
+            var version = await checker.Check();
+
+            Assert.AreEqual(new Version(1, 2, 3, 4), version);
+
+            handlerMock.Protected().Verify(
+                "SendAsync",
+                Times.Exactly(1),
+                ItExpr.Is<HttpRequestMessage>(
+                    req => req.Method == HttpMethod.Get && req.RequestUri.ToString() == "https://tjensen.github.io/DayZServerMonitor/version.txt"),
+                ItExpr.IsAny<CancellationToken>());
+        }
+
+        [TestMethod]
+        public async Task CheckReturnsNullIfLatestVersionUnableToBeParsed()
+        {
+            var handlerMock = PrepareMockHandler(
+                new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("INVALID-VERSION")
+                });
+            var client = new HttpClient(handlerMock.Object);
+            var checker = new VersionChecker(client, logger);
+
+            var version = await checker.Check();
+
+            Assert.IsNull(version);
+        }
+
+        [TestMethod]
+        public async Task CheckReturnsNullIfHttpRequestReturnsUnsuccessfulStatusCode()
+        {
+            var handlerMock = PrepareMockHandler(
+                new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.NotFound,
+                    Content = new StringContent("1.2.3.4\n")
+                });
+            var client = new HttpClient(handlerMock.Object);
+            var checker = new VersionChecker(client, logger);
+
+            var version = await checker.Check();
+
+            Assert.IsNull(version);
+        }
+
+        [TestMethod]
+        public async Task CheckReturnsNullIfHttpRequestThrowsException()
+        {
+            var handlerMock = PrepareMockHandler(new Exception("GetAsync error"));
+            var client = new HttpClient(handlerMock.Object);
+            var checker = new VersionChecker(client, logger);
+
+            var version = await checker.Check();
+
+            Assert.IsNull(version);
+        }
+    }
+}


### PR DESCRIPTION
This adds a new "Check for Update" menu item that allows the user to manually check if a newer version of the tool is available for download.

It also adds an automatic check for update when the tool is launched, which can be disabled in the settings.

Resolves #37 